### PR TITLE
Fire inputModified.formChanged event to parent scopes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,21 @@ It's all up to you!
 
 Please see [the special demo][demo-excluded-elements].
 
+### Listen to modifed event from parent scope
 
+When a form is modified, it fires an event `inputModified.formChanged`. Parent scope can listen to this event.
+
+```javascript
+/*
+*  e        --- event
+*  modified --- Boolean
+*  form     --- the modified form object
+*/
+ $scope.$on("inputModified.formChanged", function(e, modified, form) {
+       // process the modified event
+       // use form.$name to get the form name
+ });
+```
 ## API
 
 ### inputModifiedConfigProvider

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ It's all up to you!
 
 Please see [the special demo][demo-excluded-elements].
 
-### Listen to the modifed event in parent scope
+### Listening to `modifed` event in parent scope
 
 When a form is modified, it fires an event `inputModified.formChanged`. Parent scopes can listen to this event. This event passes `modified` flag and `form` object. Following is an example of parent scope listening to this event.
 

--- a/readme.md
+++ b/readme.md
@@ -124,7 +124,7 @@ It's all up to you!
 
 Please see [the special demo][demo-excluded-elements].
 
-### Listening to `modifed` event in parent scope
+### Listening to `formChanged` event in parent scope
 
 When a form is modified, it fires an event `inputModified.formChanged`. Parent scopes can listen to this event. This event passes `modified` flag and `form` object. Following is an example of parent scope listening to this event.
 

--- a/readme.md
+++ b/readme.md
@@ -124,9 +124,9 @@ It's all up to you!
 
 Please see [the special demo][demo-excluded-elements].
 
-### Listen to modifed event from parent scope
+### Listen to the modifed event in parent scope
 
-When a form is modified, it fires an event `inputModified.formChanged`. Parent scope can listen to this event.
+When a form is modified, it fires an event `inputModified.formChanged`. Parent scopes can listen to this event. This event passes `modified` flag and `form` object. Following is an example of parent scope listening to this event.
 
 ```javascript
 /*

--- a/src/directive/form.js
+++ b/src/directive/form.js
@@ -108,8 +108,8 @@
             }
 
             updateCssClasses();
-            // notify parent of the status change
-            $scope.$emit("$$formModifiedStateChanged",formCtrl.modified); 
+            // notify parent scope of the status change
+            $scope.$emit("inputModified.formChanged", formCtrl.modified, formCtrl); 
           }
 
         }

--- a/src/directive/form.js
+++ b/src/directive/form.js
@@ -108,7 +108,8 @@
             }
 
             updateCssClasses();
-
+            // notify parent of the status change
+            $scope.$emit("$$formModifiedStateChanged",formCtrl.modified); 
           }
 
         }


### PR DESCRIPTION
A modified form can inform its parent scopes of modification status change. A use case is if you have a list of form names, when one of the form is changed, you can highlight the form's name on the list.