### PR TITLE
Fire inputModified.formChanged event to parent scopes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,21 @@ It's all up to you!
 
 Please see [the special demo][demo-excluded-elements].
 
+### Listening to `formChanged` event in parent scope
+
+When a form is modified, it fires an event `inputModified.formChanged`. Parent scopes can listen to this event. This event passes `modified` flag and `form` object. Following is an example of parent scope listening to this event.
+
+```javascript
+/*
+*  e        --- event
+*  modified --- Boolean
+*  form     --- the modified form object
+*/
+ $scope.$on("inputModified.formChanged", function(e, modified, form) {
+       // process the modified event
+       // use form.$name to get the form name
+ });
+```
 
 ## API
 

--- a/src/directive/form.js
+++ b/src/directive/form.js
@@ -108,7 +108,8 @@
             }
 
             updateCssClasses();
-
+            // fire formChanged event to parent scopes
+            $scope.$emit("inputModified.formChanged", formCtrl.modified, formCtrl); 
           }
 
         }


### PR DESCRIPTION
A modified form can inform its parent scopes of modification status change. A use case is if you have a list of form names, when one of the form is changed, you can highlight the form's name on the list.